### PR TITLE
Integrate KnowledgeService into OpenCDX engine and tests

### DIFF
--- a/opencdx-classification-analyzer/src/main/java/cdx/opencdx/classification/analyzer/config/AnalyzerConfig.java
+++ b/opencdx-classification-analyzer/src/main/java/cdx/opencdx/classification/analyzer/config/AnalyzerConfig.java
@@ -36,6 +36,11 @@ public class AnalyzerConfig {
         log.info("Classification Analyzer Configuration Initializing.");
     }
 
+    /**
+     * Knowledge Service Bean
+     *
+     * @return KnowledgeService
+     */
     @Bean
     public KnowledgeService knowledgeService() {
         return new KnowledgeService();

--- a/opencdx-classification-analyzer/src/main/java/cdx/opencdx/classification/analyzer/config/AnalyzerConfig.java
+++ b/opencdx-classification-analyzer/src/main/java/cdx/opencdx/classification/analyzer/config/AnalyzerConfig.java
@@ -16,7 +16,9 @@
 package cdx.opencdx.classification.analyzer.config;
 
 import lombok.extern.slf4j.Slf4j;
+import org.evrete.KnowledgeService;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -32,5 +34,10 @@ public class AnalyzerConfig {
     public AnalyzerConfig() {
         // Explicit declaration to prevent this class from inadvertently being made instantiable
         log.info("Classification Analyzer Configuration Initializing.");
+    }
+
+    @Bean
+    public KnowledgeService knowledgeService() {
+        return new KnowledgeService();
     }
 }

--- a/opencdx-classification-analyzer/src/main/java/cdx/opencdx/classification/analyzer/service/impl/OpenCDXAnalysisEngineImpl.java
+++ b/opencdx-classification-analyzer/src/main/java/cdx/opencdx/classification/analyzer/service/impl/OpenCDXAnalysisEngineImpl.java
@@ -33,10 +33,6 @@ import cdx.opencdx.grpc.service.logistics.TestCaseListRequest;
 import cdx.opencdx.grpc.service.logistics.TestCaseListResponse;
 import cdx.opencdx.grpc.types.ClassificationType;
 import io.micrometer.observation.annotation.Observed;
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tika.mime.MimeType;
 import org.apache.tika.mime.MimeTypeException;
@@ -47,6 +43,11 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 
 /**
  * Demonstration implementation of the OpenCDXAnalysisEngine class. This class is responsible for analyzing the patient's questionnaire and connected test data,
@@ -76,16 +77,18 @@ public class OpenCDXAnalysisEngineImpl implements OpenCDXAnalysisEngine {
      * @param openCDXMediaUpDownClient the OpenCDXMediaUpDownClient object to download media
      * @param openCDXTestCaseClient the OpenCDXTestCaseClient object to get test cases
      * @param openCDXCurrentUser the OpenCDXCurrentUser object to get the current user
+     * @param knowledgeService the KnowledgeService object to create rules knowledge
      */
     public OpenCDXAnalysisEngineImpl(
             OpenCDXMediaUpDownClient openCDXMediaUpDownClient,
             OpenCDXTestCaseClient openCDXTestCaseClient,
-            OpenCDXCurrentUser openCDXCurrentUser) {
+            OpenCDXCurrentUser openCDXCurrentUser,
+            KnowledgeService knowledgeService) {
         this.openCDXMediaUpDownClient = openCDXMediaUpDownClient;
         this.openCDXTestCaseClient = openCDXTestCaseClient;
         this.openCDXCurrentUser = openCDXCurrentUser;
         this.random = new Random();
-        this.knowledgeService = new KnowledgeService();
+        this.knowledgeService = knowledgeService;
     }
 
     /**

--- a/opencdx-classification-analyzer/src/test/java/cdx/opencdx/classification/analyzer/service/impl/OpenCDXAnalysisEngineImplTest.java
+++ b/opencdx-classification-analyzer/src/test/java/cdx/opencdx/classification/analyzer/service/impl/OpenCDXAnalysisEngineImplTest.java
@@ -15,9 +15,6 @@
  */
 package cdx.opencdx.classification.analyzer.service.impl;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
 import cdx.opencdx.classification.analyzer.dto.RuleResult;
 import cdx.opencdx.classification.analyzer.rules.BloodPressureRules;
 import cdx.opencdx.client.service.OpenCDXMediaUpDownClient;
@@ -30,8 +27,6 @@ import cdx.opencdx.grpc.data.*;
 import cdx.opencdx.grpc.service.classification.RuleSetsRequest;
 import cdx.opencdx.grpc.service.logistics.TestCaseListResponse;
 import cdx.opencdx.grpc.types.ClassificationType;
-import java.io.IOException;
-import java.util.List;
 import org.evrete.KnowledgeService;
 import org.evrete.api.Knowledge;
 import org.evrete.api.StatelessSession;
@@ -43,21 +38,29 @@ import org.mockito.stubbing.Answer;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
 @SuppressWarnings("java:S5976")
 class OpenCDXAnalysisEngineImplTest {
 
     OpenCDXMediaUpDownClient openCDXMediaUpDownClient;
     OpenCDXTestCaseClient openCDXTestCaseClient;
     OpenCDXCurrentUser openCDXCurrentUser;
+    KnowledgeService knowledgeService;
 
     @Test
     void getRuleSets() {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         Assertions.assertNotNull(engine.getRuleSets(request));
     }
 
@@ -66,9 +69,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         UserQuestionnaireData userQuestionnaireData = UserQuestionnaireData.newBuilder()
                 .setId(OpenCDXIdentifier.get().toHexString())
                 .build();
@@ -97,9 +101,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         UserQuestionnaireData userQuestionnaireData = UserQuestionnaireData.newBuilder()
                 .setId(OpenCDXIdentifier.get().toHexString())
                 .build();
@@ -129,9 +134,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         UserQuestionnaireData userQuestionnaireData = UserQuestionnaireData.newBuilder()
                 .setId(OpenCDXIdentifier.get().toHexString())
                 .addAllQuestionnaireData(List.of(Questionnaire.newBuilder()
@@ -164,9 +170,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         UserQuestionnaireData userQuestionnaireData = UserQuestionnaireData.newBuilder()
                 .setId(OpenCDXIdentifier.get().toHexString())
                 .addAllQuestionnaireData(List.of(Questionnaire.newBuilder()
@@ -199,9 +206,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         UserQuestionnaireData userQuestionnaireData = UserQuestionnaireData.newBuilder()
                 .setId(OpenCDXIdentifier.get().toHexString())
                 .addAllQuestionnaireData(List.of(Questionnaire.newBuilder()
@@ -232,8 +240,7 @@ class OpenCDXAnalysisEngineImplTest {
         //                OpenCDXInternal.class,
         //                () -> engine.analyzeQuestionnaire(openCDXProfileModel, userAnswer, media,
         // userQuestionnaireData));
-        Assertions.assertThrows(
-                NullPointerException.class,
+        Assertions.assertDoesNotThrow(
                 () -> engine.analyzeQuestionnaire(openCDXProfileModel, userAnswer, media, userQuestionnaireData));
     }
 
@@ -242,9 +249,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         UserQuestionnaireData userQuestionnaireData = UserQuestionnaireData.newBuilder()
                 .setId(OpenCDXIdentifier.get().toHexString())
                 .addAllQuestionnaireData(List.of(Questionnaire.newBuilder()
@@ -284,9 +292,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         QuestionnaireItem questionnaireItem = QuestionnaireItem.newBuilder()
                 .setLinkId("q1")
                 .setType("boolean")
@@ -364,9 +373,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         QuestionnaireItem questionnaireItem = QuestionnaireItem.newBuilder()
                 .setLinkId("q1")
                 .setType("boolean")
@@ -444,9 +454,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         QuestionnaireItem questionnaireItem = QuestionnaireItem.newBuilder()
                 .setLinkId("q1")
                 .setType("boolean")
@@ -515,8 +526,7 @@ class OpenCDXAnalysisEngineImplTest {
 
         statelessSession.insertAndFire(anyBoolean(), Mockito.eq(result));
         when(knowledge.newStatelessSession()).thenReturn(statelessSession);
-        Assertions.assertThrows(
-                NullPointerException.class,
+        Assertions.assertDoesNotThrow(
                 () -> engine.analyzeQuestionnaire(openCDXProfileModel, userAnswer, media, userQuestionnaireData));
     }
 
@@ -525,9 +535,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         QuestionnaireItem questionnaireItem = QuestionnaireItem.newBuilder()
                 .setLinkId("q1")
                 .setType("boolean")
@@ -596,8 +607,7 @@ class OpenCDXAnalysisEngineImplTest {
 
         statelessSession.insertAndFire(anyBoolean(), Mockito.eq(result));
         when(knowledge.newStatelessSession()).thenReturn(statelessSession);
-        Assertions.assertThrows(
-                NullPointerException.class,
+        Assertions.assertDoesNotThrow(
                 () -> engine.analyzeQuestionnaire(openCDXProfileModel, userAnswer, media, userQuestionnaireData));
     }
 
@@ -606,9 +616,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         QuestionnaireItem questionnaireItem = QuestionnaireItem.newBuilder()
                 .setLinkId("q1")
                 .setType("boolean")
@@ -677,8 +688,7 @@ class OpenCDXAnalysisEngineImplTest {
 
         statelessSession.insertAndFire(anyBoolean(), Mockito.eq(result));
         when(knowledge.newStatelessSession()).thenReturn(statelessSession);
-        Assertions.assertThrows(
-                NullPointerException.class,
+        Assertions.assertDoesNotThrow(
                 () -> engine.analyzeQuestionnaire(openCDXProfileModel, userAnswer, media, userQuestionnaireData));
     }
 
@@ -687,9 +697,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         QuestionnaireItem questionnaireItem = QuestionnaireItem.newBuilder()
                 .setLinkId("q1")
                 .setType("boolean")
@@ -771,9 +782,10 @@ class OpenCDXAnalysisEngineImplTest {
         this.openCDXCurrentUser = Mockito.mock(OpenCDXCurrentUser.class);
         this.openCDXTestCaseClient = Mockito.mock(OpenCDXTestCaseClient.class);
         this.openCDXMediaUpDownClient = Mockito.mock(OpenCDXMediaUpDownClient.class);
+        this.knowledgeService = Mockito.mock(KnowledgeService.class);
         RuleSetsRequest request = RuleSetsRequest.newBuilder().build();
-        OpenCDXAnalysisEngineImpl engine =
-                new OpenCDXAnalysisEngineImpl(openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser);
+        OpenCDXAnalysisEngineImpl engine = new OpenCDXAnalysisEngineImpl(
+                openCDXMediaUpDownClient, openCDXTestCaseClient, openCDXCurrentUser, knowledgeService);
         QuestionnaireItem questionnaireItem = QuestionnaireItem.newBuilder()
                 .setLinkId("q1")
                 .setType("string")

--- a/opencdx-classification/src/test/java/cdx/opencdx/classification/service/impl/OpenCDXClassificationServiceImplTest.java
+++ b/opencdx-classification/src/test/java/cdx/opencdx/classification/service/impl/OpenCDXClassificationServiceImplTest.java
@@ -15,9 +15,6 @@
  */
 package cdx.opencdx.classification.service.impl;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-
 import cdx.opencdx.classification.analyzer.service.impl.OpenCDXAnalysisEngineImpl;
 import cdx.opencdx.classification.model.OpenCDXClassificationModel;
 import cdx.opencdx.classification.repository.OpenCDXClassificationRepository;
@@ -48,9 +45,7 @@ import cdx.opencdx.grpc.types.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.Timestamp;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import org.evrete.KnowledgeService;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -70,6 +65,13 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ActiveProfiles({"test", "managed"})
 @ExtendWith(SpringExtension.class)
@@ -128,6 +130,9 @@ class OpenCDXClassificationServiceImplTest {
 
     @Mock
     OpenCDXCommunicationService openCDXCommunicationService;
+
+    @Autowired
+    KnowledgeService knowledgeService;
 
     @BeforeEach
     void beforeEach() {
@@ -289,7 +294,10 @@ class OpenCDXClassificationServiceImplTest {
                         .build());
 
         this.openCDXClassifyProcessorService = new OpenCDXAnalysisEngineImpl(
-                this.openCDXMediaUpDownClient, this.openCDXTestCaseClient, this.openCDXCurrentUser);
+                this.openCDXMediaUpDownClient,
+                this.openCDXTestCaseClient,
+                this.openCDXCurrentUser,
+                this.knowledgeService);
 
         this.classificationService = new OpenCDXClassificationServiceImpl(
                 this.openCDXAuditService,


### PR DESCRIPTION
KnowledgeService has been integrated into the OpenCDXAnalysisEngineImpl class to handle rule knowledge. The KnowledgeService instance is now provided through dependency injection in both the service implementation and test classes. Additionally, refactoring was done in the test classes to accommodate this new dependency.