### PR TITLE
Refactor login exception message for better clarity

### DIFF
--- a/opencdx-iam/src/main/java/cdx/opencdx/iam/service/impl/OpenCDXIAMUserServiceImpl.java
+++ b/opencdx-iam/src/main/java/cdx/opencdx/iam/service/impl/OpenCDXIAMUserServiceImpl.java
@@ -535,8 +535,7 @@ public class OpenCDXIAMUserServiceImpl implements OpenCDXIAMUserService {
     public LoginResponse login(LoginRequest request) {
         OpenCDXIAMUserModel userModel = this.openCDXIAMUserRepository
                 .findByUsername(request.getUserName())
-                .orElseThrow(() ->
-                        new OpenCDXUnauthorized(DOMAIN, 1, "Failed to authenticate user: " + request.getUserName()));
+                .orElseThrow(() -> new OpenCDXUnauthorized(DOMAIN, 1, FAILED_TO_FIND_USER + request.getUserName()));
         try {
 
             if (Boolean.TRUE.equals(userModel.getEmailVerified())) {


### PR DESCRIPTION
Simplified the exception message construction during user authentication by leveraging the predefined constant FAILED_TO_FIND_USER. This reduces redundancy and enhances code maintainability.