### PR TITLE
Refactor index setup for users collection

### DIFF
--- a/opencdx-iam/src/main/java/cdx/opencdx/iam/changelog/IAMChangeSet.java
+++ b/opencdx-iam/src/main/java/cdx/opencdx/iam/changelog/IAMChangeSet.java
@@ -39,6 +39,7 @@ public class IAMChangeSet {
     private static final String SCRAMBLED_PASSWORD =
             "{bcrypt}$2a$10$FLbaCLMQvIW8u5ceN4BStujPq8dbXeyeIiazOPatFUwcaopXNqlAa";
     private static final String SYSTEM = "SYSTEM";
+    private static final String USERS = "users";
 
     /**
      * Default Constructor
@@ -175,19 +176,6 @@ public class IAMChangeSet {
     }
 
     /**
-     * Setup Index on email for users.
-     * @param mongockTemplate MongockTemplate to modify MongoDB.
-     * @param openCDXCurrentUser Current User to use for authentication.
-     */
-    @ChangeSet(order = "002", id = "Setup Users Email Index", author = "Gaurav Mishra")
-    public void setupIndexes(MongockTemplate mongockTemplate, OpenCDXCurrentUser openCDXCurrentUser) {
-        openCDXCurrentUser.configureAuthentication(SYSTEM);
-        mongockTemplate
-                .getCollection("users")
-                .createIndex(Indexes.ascending(List.of("username")), new IndexOptions().unique(true));
-    }
-
-    /**
      * Setup Default User for OpenCDX
      * @param openCDXIAMUserRepository User Repository for saving default user.
      * @param openCDXCurrentUser Current User to use for authentication.
@@ -211,11 +199,12 @@ public class IAMChangeSet {
      * @param mongockTemplate MongockTemplate to modify MongoDB.
      * @param openCDXCurrentUser Current User to use for authentication.
      */
-    @ChangeSet(order = "004", id = "Setup Users System Index", author = "Jeff Miller")
+    @ChangeSet(order = "005", id = "Setup Users Indexes", author = "Jeff Miller")
     public void setupSystemIndex(MongockTemplate mongockTemplate, OpenCDXCurrentUser openCDXCurrentUser) {
-        openCDXCurrentUser.configureAuthentication(SYSTEM);
+        mongockTemplate.getCollection(USERS).dropIndexes();
         mongockTemplate
-                .getCollection("users")
-                .createIndex(Indexes.ascending(List.of("systemName")), new IndexOptions().unique(true));
+                .getCollection(USERS)
+                .createIndex(Indexes.ascending(List.of("username")), new IndexOptions().unique(true));
+        mongockTemplate.getCollection(USERS).createIndex(Indexes.ascending(List.of("systemName")));
     }
 }


### PR DESCRIPTION
Removed duplicate index setup method and consolidated index creation logic for the users collection into a single method. The new method now drops all existing indexes before creating unique indexes for username and non-unique indexes for systemName.